### PR TITLE
Node is an interface, and we use it rather than *Node

### DIFF
--- a/gossip.go
+++ b/gossip.go
@@ -3,7 +3,7 @@ package hyparview
 func (v *Hyparview) Gossip(m Message) {
 	v.repairAsymmetry(m)
 	for _, n := range v.Active.Nodes {
-		if n.Equal(m.From()) {
+		if EqualNode(n, m.From()) {
 			continue
 		}
 

--- a/hyparview_test.go
+++ b/hyparview_test.go
@@ -8,12 +8,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func makeNodes(n int) []*Node {
-	ns := make([]*Node, n)
+func makeNodes(n int) []Node {
+	ns := make([]Node, n)
 	for i := 0; i < n; i++ {
-		ns[i] = &Node{
-			ID:   fmt.Sprintf("127.0.0.1:1000%d", i),
-			Addr: fmt.Sprintf("127.0.0.1:1000%d", i),
+		ns[i] = &node{
+			addr: fmt.Sprintf("127.0.0.1:1000%d", i),
 		}
 	}
 	return ns
@@ -28,10 +27,10 @@ func (s *sliceSender) Send(m Message) (*NeighborRefuse, error) {
 	return nil, nil
 }
 
-func (s *sliceSender) Failed(n *Node) {
+func (s *sliceSender) Failed(n Node) {
 }
 
-func (s *sliceSender) Bootstrap() *Node {
+func (s *sliceSender) Bootstrap() Node {
 	return nil
 }
 
@@ -47,7 +46,7 @@ func newSliceSender() *sliceSender {
 	return s
 }
 
-func testView(count int) (*Hyparview, []*Node) {
+func testView(count int) (*Hyparview, []Node) {
 	ns := makeNodes(count)
 	hv := CreateView(newSliceSender(), ns[0], 0)
 	return hv, ns
@@ -174,7 +173,7 @@ func TestNeighborSymmetry(t *testing.T) {
 	rand.Seed(0)
 	v["a"].RecvJoin(NewJoin(v["a"].Self, NewNode("d")))
 	for _, m := range s["a"].reset() {
-		t := m.To().ID
+		t := m.To().Addr()
 		v[t].Recv(m)
 	}
 

--- a/message-generated.go
+++ b/message-generated.go
@@ -4,100 +4,100 @@
 
 package hyparview
 
-func (r *JoinRequest) To() *Node {
+func (r *JoinRequest) To() Node {
 	return r.to
 }
 
-func (r *JoinRequest) AssocTo(n *Node) Message {
+func (r *JoinRequest) AssocTo(n Node) Message {
 	o := *r
 	o.to = n
 	return &o
 }
 
-func (r *JoinRequest) From() *Node {
+func (r *JoinRequest) From() Node {
 	return r.from
 }
 
-func (r *ForwardJoinRequest) To() *Node {
+func (r *ForwardJoinRequest) To() Node {
 	return r.to
 }
 
-func (r *ForwardJoinRequest) AssocTo(n *Node) Message {
+func (r *ForwardJoinRequest) AssocTo(n Node) Message {
 	o := *r
 	o.to = n
 	return &o
 }
 
-func (r *ForwardJoinRequest) From() *Node {
+func (r *ForwardJoinRequest) From() Node {
 	return r.from
 }
 
-func (r *DisconnectRequest) To() *Node {
+func (r *DisconnectRequest) To() Node {
 	return r.to
 }
 
-func (r *DisconnectRequest) AssocTo(n *Node) Message {
+func (r *DisconnectRequest) AssocTo(n Node) Message {
 	o := *r
 	o.to = n
 	return &o
 }
 
-func (r *DisconnectRequest) From() *Node {
+func (r *DisconnectRequest) From() Node {
 	return r.from
 }
 
-func (r *NeighborRequest) To() *Node {
+func (r *NeighborRequest) To() Node {
 	return r.to
 }
 
-func (r *NeighborRequest) AssocTo(n *Node) Message {
+func (r *NeighborRequest) AssocTo(n Node) Message {
 	o := *r
 	o.to = n
 	return &o
 }
 
-func (r *NeighborRequest) From() *Node {
+func (r *NeighborRequest) From() Node {
 	return r.from
 }
 
-func (r *NeighborRefuse) To() *Node {
+func (r *NeighborRefuse) To() Node {
 	return r.to
 }
 
-func (r *NeighborRefuse) AssocTo(n *Node) Message {
+func (r *NeighborRefuse) AssocTo(n Node) Message {
 	o := *r
 	o.to = n
 	return &o
 }
 
-func (r *NeighborRefuse) From() *Node {
+func (r *NeighborRefuse) From() Node {
 	return r.from
 }
 
-func (r *ShuffleRequest) To() *Node {
+func (r *ShuffleRequest) To() Node {
 	return r.to
 }
 
-func (r *ShuffleRequest) AssocTo(n *Node) Message {
+func (r *ShuffleRequest) AssocTo(n Node) Message {
 	o := *r
 	o.to = n
 	return &o
 }
 
-func (r *ShuffleRequest) From() *Node {
+func (r *ShuffleRequest) From() Node {
 	return r.from
 }
 
-func (r *ShuffleReply) To() *Node {
+func (r *ShuffleReply) To() Node {
 	return r.to
 }
 
-func (r *ShuffleReply) AssocTo(n *Node) Message {
+func (r *ShuffleReply) AssocTo(n Node) Message {
 	o := *r
 	o.to = n
 	return &o
 }
 
-func (r *ShuffleReply) From() *Node {
+func (r *ShuffleReply) From() Node {
 	return r.from
 }

--- a/message.go
+++ b/message.go
@@ -2,9 +2,9 @@ package hyparview
 
 // Message allows clients to redefine hyparview messages to carry additional meta information
 type Message interface {
-	To() *Node
-	AssocTo(*Node) Message
-	From() *Node
+	To() Node
+	AssocTo(Node) Message
+	From() Node
 }
 
 // Methods that can be generated should be added to message.go.genny, and build by `make
@@ -17,11 +17,11 @@ const (
 )
 
 type JoinRequest struct {
-	to   *Node
-	from *Node
+	to   Node
+	from Node
 }
 
-func NewJoin(to *Node, from *Node) *JoinRequest {
+func NewJoin(to Node, from Node) *JoinRequest {
 	return &JoinRequest{
 		to:   to,
 		from: from,
@@ -29,13 +29,13 @@ func NewJoin(to *Node, from *Node) *JoinRequest {
 }
 
 type ForwardJoinRequest struct {
-	to   *Node
-	from *Node
-	Join *Node
+	to   Node
+	from Node
+	Join Node
 	TTL  int
 }
 
-func NewForwardJoin(to *Node, from *Node, join *Node, ttl int) *ForwardJoinRequest {
+func NewForwardJoin(to Node, from Node, join Node, ttl int) *ForwardJoinRequest {
 	return &ForwardJoinRequest{
 		to:   to,
 		from: from,
@@ -45,11 +45,11 @@ func NewForwardJoin(to *Node, from *Node, join *Node, ttl int) *ForwardJoinReque
 }
 
 type DisconnectRequest struct {
-	to   *Node
-	from *Node
+	to   Node
+	from Node
 }
 
-func NewDisconnect(to *Node, from *Node) *DisconnectRequest {
+func NewDisconnect(to Node, from Node) *DisconnectRequest {
 	return &DisconnectRequest{
 		to:   to,
 		from: from,
@@ -57,13 +57,13 @@ func NewDisconnect(to *Node, from *Node) *DisconnectRequest {
 }
 
 type NeighborRequest struct {
-	to       *Node
-	from     *Node
+	to       Node
+	from     Node
 	Priority bool
 	Join     bool
 }
 
-func NewNeighbor(to *Node, from *Node, priority bool) *NeighborRequest {
+func NewNeighbor(to Node, from Node, priority bool) *NeighborRequest {
 	return &NeighborRequest{
 		to:       to,
 		from:     from,
@@ -71,7 +71,7 @@ func NewNeighbor(to *Node, from *Node, priority bool) *NeighborRequest {
 	}
 }
 
-func NewNeighborJoin(to *Node, from *Node) *NeighborRequest {
+func NewNeighborJoin(to Node, from Node) *NeighborRequest {
 	return &NeighborRequest{
 		to:       to,
 		from:     from,
@@ -81,11 +81,11 @@ func NewNeighborJoin(to *Node, from *Node) *NeighborRequest {
 }
 
 type NeighborRefuse struct {
-	to   *Node
-	from *Node
+	to   Node
+	from Node
 }
 
-func NewNeighborRefuse(to *Node, from *Node) *NeighborRefuse {
+func NewNeighborRefuse(to Node, from Node) *NeighborRefuse {
 	return &NeighborRefuse{
 		to:   to,
 		from: from,
@@ -93,15 +93,15 @@ func NewNeighborRefuse(to *Node, from *Node) *NeighborRefuse {
 }
 
 type ShuffleRequest struct {
-	to      *Node
-	from    *Node
-	Origin  *Node
-	Active  []*Node
-	Passive []*Node
+	to      Node
+	from    Node
+	Origin  Node
+	Active  []Node
+	Passive []Node
 	TTL     int
 }
 
-func NewShuffle(to, from, origin *Node, active, passive []*Node, ttl int) *ShuffleRequest {
+func NewShuffle(to, from, origin Node, active, passive []Node, ttl int) *ShuffleRequest {
 	return &ShuffleRequest{
 		to:      to,
 		from:    from,
@@ -113,12 +113,12 @@ func NewShuffle(to, from, origin *Node, active, passive []*Node, ttl int) *Shuff
 }
 
 type ShuffleReply struct {
-	to      *Node
-	from    *Node
-	Passive []*Node
+	to      Node
+	from    Node
+	Passive []Node
 }
 
-func NewShuffleReply(to *Node, from *Node, passive []*Node) *ShuffleReply {
+func NewShuffleReply(to Node, from Node, passive []Node) *ShuffleReply {
 	return &ShuffleReply{
 		to:      to,
 		from:    from,

--- a/message.go.genny
+++ b/message.go.genny
@@ -6,16 +6,16 @@ type genericReq generic.Type
 
 //go:generate genny -in=$GOFILE -out=gen-$GOFILE gen "genericReq=*JoinRequest,*ForwardJoinRequest,*DisconnectRequest,*NeighborRequest,*NeighborRefuse,*ShuffleRequest,*ShuffleReply"
 
-func (r genericReq) To() *Node {
+func (r genericReq) To() Node {
 	return r.to
 }
 
-func (r genericReq) AssocTo(n *Node) Message {
+func (r genericReq) AssocTo(n Node) Message {
 	o := *r
 	o.to = n
 	return &o
 }
 
-func (r genericReq) From() *Node {
+func (r genericReq) From() Node {
 	return r.from
 }

--- a/message_test.go
+++ b/message_test.go
@@ -7,9 +7,9 @@ import (
 )
 
 func TestAssocTo(t *testing.T) {
-	a := &Node{ID: "a"}
-	b := &Node{ID: "b"}
-	c := &Node{ID: "c"}
+	a := NewNode("a")
+	b := NewNode("b")
+	c := NewNode("c")
 	m := NewJoin(a, b)
 	n := m.AssocTo(c)
 

--- a/node.go
+++ b/node.go
@@ -1,20 +1,24 @@
 package hyparview
 
-type Node struct {
-	ID   string
-	Addr string
+type Node interface {
+	Addr() string
 }
 
-func NewNode(addr string) *Node {
-	return &Node{
-		ID:   addr,
-		Addr: addr,
-	}
+type node struct {
+	addr string
 }
 
-func (n *Node) Equal(m *Node) bool {
+func (n *node) Addr() string {
+	return n.addr
+}
+
+func NewNode(addr string) Node {
+	return &node{addr: addr}
+}
+
+func EqualNode(n, m Node) bool {
 	if n == nil || m == nil {
 		return n == m
 	}
-	return n.ID == m.ID // FIXME both?
+	return n.Addr() == m.Addr()
 }

--- a/part.go
+++ b/part.go
@@ -1,13 +1,13 @@
 package hyparview
 
 type ViewPart struct {
-	Nodes []*Node
+	Nodes []Node
 	Max   int
 }
 
 func CreateViewPart(size int) *ViewPart {
 	return &ViewPart{
-		Nodes: []*Node{},
+		Nodes: []Node{},
 		Max:   size,
 	}
 }
@@ -16,10 +16,10 @@ func (v *ViewPart) IsEmpty() bool {
 	return len(v.Nodes) <= 1
 }
 
-func (v *ViewPart) IsEmptyBut(peer *Node) bool {
+func (v *ViewPart) IsEmptyBut(peer Node) bool {
 	return v.IsEmpty() ||
 		(len(v.Nodes) == 1 &&
-			peer.Equal(v.Nodes[0]))
+			EqualNode(peer, v.Nodes[0]))
 }
 
 func (v *ViewPart) IsFull() bool {
@@ -32,7 +32,7 @@ func (v *ViewPart) Size() int {
 
 func (v *ViewPart) Copy() *ViewPart {
 	w := *v
-	nodes := make([]*Node, len(v.Nodes))
+	nodes := make([]Node, len(v.Nodes))
 	copy(nodes, v.Nodes)
 	w.Nodes = nodes
 	return &w
@@ -48,7 +48,7 @@ func (v *ViewPart) Equal(w *ViewPart) bool {
 setwise:
 	for _, n := range v.Nodes {
 		for _, m := range w.Nodes {
-			if n.Equal(m) {
+			if EqualNode(n, m) {
 				continue setwise
 			}
 		}
@@ -57,7 +57,7 @@ setwise:
 	return true
 }
 
-func (v *ViewPart) Add(n *Node) {
+func (v *ViewPart) Add(n Node) {
 	if !v.Contains(n) {
 		v.Nodes = append(v.Nodes, n)
 	}
@@ -68,7 +68,7 @@ func (v *ViewPart) DelIndex(i int) {
 	v.Nodes = append(ns[:i], ns[i+1:]...)
 }
 
-func (v *ViewPart) DelNode(n *Node) bool {
+func (v *ViewPart) DelNode(n Node) bool {
 	idx := v.ContainsIndex(n)
 	if idx >= 0 {
 		v.DelIndex(idx)
@@ -77,13 +77,13 @@ func (v *ViewPart) DelNode(n *Node) bool {
 	return false
 }
 
-func (v *ViewPart) GetIndex(i int) *Node {
+func (v *ViewPart) GetIndex(i int) Node {
 	return v.Nodes[i]
 }
 
-func (v *ViewPart) Shuffled() []*Node {
+func (v *ViewPart) Shuffled() []Node {
 	l := len(v.Nodes)
-	ns := make([]*Node, l)
+	ns := make([]Node, l)
 	// Start with a copy, fischer-yates needs to operate destructively
 	copy(ns, v.Nodes)
 	for i := l - 1; i > 0; i-- {
@@ -97,19 +97,19 @@ func (v *ViewPart) RandIndex() int {
 	return Rint(len(v.Nodes) - 1)
 }
 
-func (v *ViewPart) RandNode() *Node {
+func (v *ViewPart) RandNode() Node {
 	return v.Nodes[v.RandIndex()]
 }
 
-func (v *ViewPart) ContainsIndex(n *Node) int {
+func (v *ViewPart) ContainsIndex(n Node) int {
 	for i, m := range v.Nodes {
-		if m.Equal(n) {
+		if EqualNode(n, m) {
 			return i
 		}
 	}
 	return -1
 }
 
-func (v *ViewPart) Contains(n *Node) bool {
+func (v *ViewPart) Contains(n Node) bool {
 	return v.ContainsIndex(n) >= 0
 }

--- a/part_test.go
+++ b/part_test.go
@@ -26,7 +26,7 @@ func TestContains(t *testing.T) {
 
 	v.DelNode(n)
 
-	require.Equal(t, "a", v.Nodes[0].ID)
-	require.Equal(t, "c", v.Nodes[1].ID)
-	require.Equal(t, "e", v.Nodes[2].ID)
+	require.Equal(t, "a", v.Nodes[0].Addr())
+	require.Equal(t, "c", v.Nodes[1].Addr())
+	require.Equal(t, "e", v.Nodes[2].Addr())
 }

--- a/simulation/client.go
+++ b/simulation/client.go
@@ -17,8 +17,8 @@ type Client struct {
 	appWaste       int // count of app messages that didn't change the value
 }
 
-func makeClient(w *World, id string) *Client {
-	n := &h.Node{ID: id, Addr: id}
+func makeClient(w *World, addr string) *Client {
+	n := h.NewNode(addr)
 	v := h.CreateView(nil, n, 0)
 	c := &Client{
 		Hyparview: *v,
@@ -59,7 +59,7 @@ func (c *Client) Send(m h.Message) (*h.NeighborRefuse, error) {
 	}
 
 	c.history = append(c.history, m)
-	peer := c.w.get(m.To().ID)
+	peer := c.w.get(m.To().Addr())
 	o := peer.recv(m)
 	if o != nil {
 		c.history = append(c.history, o)
@@ -71,10 +71,10 @@ func (c *Client) Send(m h.Message) (*h.NeighborRefuse, error) {
 	return o, nil
 }
 
-func (c *Client) Failed(peer *h.Node) {
+func (c *Client) Failed(peer h.Node) {
 }
 
-func (c *Client) Bootstrap() *h.Node {
+func (c *Client) Bootstrap() h.Node {
 	c.bootstrapCount += 1
 	c.SendJoin(c.w.bootstrap)
 	return c.w.bootstrap

--- a/simulation/debug.go
+++ b/simulation/debug.go
@@ -14,8 +14,8 @@ func (w *World) symCheck(m h.Message) {
 	// 	w.spinCountM = map[string]int{}
 	// }
 
-	// n := w.get(m.FromNode().ID)
-	// p := w.get(m.To().ID)
+	// n := w.get(m.FromNode().Addr())
+	// p := w.get(m.To().Addr())
 	// if n.Active.Contains(p.Self) != p.Active.Contains(n.Self) {
 	// 	pretty.Log("asymmetric", m)
 	// }
@@ -23,16 +23,16 @@ func (w *World) symCheck(m h.Message) {
 
 	switch m1 := m.(type) {
 	// case *h.JoinRequest:
-	// 	fmt.Printf("%s %s\n", m1.To().ID, m1.From().ID)
+	// 	fmt.Printf("%s %s\n", m1.To().Addr(), m1.From().Addr())
 
 	case *h.ForwardJoinRequest:
 		if w.spinCount >= 1000000 {
 			w.spinCount = 0
-			log.Printf("fwd  1m %s %d", m1.Join.ID, m1.TTL)
+			log.Printf("fwd  1m %s %d", m1.Join.Addr(), m1.TTL)
 		} else {
 			w.spinCount += 1
 		}
-		if m1.From().ID == m1.To().ID {
+		if m1.From().Addr() == m1.To().Addr() {
 			log.Printf("fwd  dup")
 		}
 		if m1.TTL < 0 {
@@ -40,27 +40,27 @@ func (w *World) symCheck(m h.Message) {
 		}
 
 	case *h.DisconnectRequest:
-		if m1.From().ID == m1.To().ID {
+		if m1.From().Addr() == m1.To().Addr() {
 			log.Printf("diss dup")
 		}
-		n := w.get(m1.From().ID)
-		m := w.get(m.To().ID)
+		n := w.get(m1.From().Addr())
+		m := w.get(m.To().Addr())
 		if n.Active.Contains(m.Self) {
-			log.Printf("diss %s %s", m1.From().ID, m1.To().ID)
+			log.Printf("diss %s %s", m1.From().Addr(), m1.To().Addr())
 		}
 
 		if m.Active.Contains(n.Self) {
-			log.Printf("disr %s %s", m1.From().ID, m1.To().ID)
+			log.Printf("disr %s %s", m1.From().Addr(), m1.To().Addr())
 		}
 
 	case *h.NeighborRequest:
-		if !m1.Join || m1.From().ID == m1.To().ID {
+		if !m1.Join || m1.From().Addr() == m1.To().Addr() {
 			return
 		}
-		n := w.get(m1.From().ID)
-		m := w.get(m.To().ID)
+		n := w.get(m1.From().Addr())
+		m := w.get(m.To().Addr())
 		if !(n.Active.Contains(m.Self) && m.Active.Contains(n.Self)) {
-			log.Printf("nei %s %s", m1.From().ID, m1.To().ID)
+			log.Printf("nei %s %s", m1.From().Addr(), m1.To().Addr())
 		}
 	default:
 	}

--- a/simulation/gossip.go
+++ b/simulation/gossip.go
@@ -3,24 +3,24 @@ package simulation
 import h "github.com/hashicorp/hyparview"
 
 type gossip struct {
-	to   *h.Node
-	from *h.Node
+	to   h.Node
+	from h.Node
 	app  int
 	hops int
 }
 
 // Implement the message interface for gossip
-func (r *gossip) To() *h.Node {
+func (r *gossip) To() h.Node {
 	return r.to
 }
 
-func (r *gossip) AssocTo(n *h.Node) h.Message {
+func (r *gossip) AssocTo(n h.Node) h.Message {
 	o := *r
 	o.to = n
 	return &o
 }
 
-func (r *gossip) From() *h.Node {
+func (r *gossip) From() h.Node {
 	return r.from
 }
 

--- a/simulation/world.go
+++ b/simulation/world.go
@@ -6,7 +6,7 @@ type World struct {
 	config        *WorldConfig
 	nodes         map[string]*Client
 	morgue        map[string]*Client
-	bootstrap     *h.Node
+	bootstrap     h.Node
 	totalMessages int
 	totalPayloads int
 

--- a/simulation/world_plot.go
+++ b/simulation/world_plot.go
@@ -19,20 +19,20 @@ func (w *World) Connected() error {
 		lost[k] = v
 	}
 
-	var lp func(*h.Node)
-	lp = func(n *h.Node) {
-		if _, ok := lost[n.ID]; !ok {
+	var lp func(h.Node)
+	lp = func(n h.Node) {
+		if _, ok := lost[n.Addr()]; !ok {
 			return
 		}
 
-		delete(lost, n.ID)
-		for _, m := range w.get(n.ID).Active.Shuffled() {
+		delete(lost, n.Addr())
+		for _, m := range w.get(n.Addr()).Active.Shuffled() {
 			lp(m)
 		}
 	}
 
 	// I hate that this is lp(first(nodes))
-	var start *h.Node
+	var start h.Node
 	for _, v := range w.nodes {
 		start = v.Self
 		break
@@ -59,7 +59,7 @@ func (w *World) isSymmetric() error {
 	count := 0
 	for _, n := range w.nodes {
 		for _, p := range n.Active.Shuffled() {
-			if !w.get(p.ID).Active.Contains(n.Self) {
+			if !w.get(p.Addr()).Active.Contains(n.Self) {
 				count++
 				break
 			}
@@ -96,7 +96,7 @@ func (w *World) plotOutDegree() {
 	plot := func(ns func(*h.Hyparview) int, path string) {
 		act := map[string]int{}
 		for _, n := range w.nodes {
-			act[n.Self.ID] = ns(&n.Hyparview)
+			act[n.Self.Addr()] = ns(&n.Hyparview)
 		}
 
 		max := 0
@@ -128,12 +128,12 @@ func (w *World) plotOutDegree() {
 }
 
 func (w *World) plotInDegree() {
-	plot := func(ns func(*h.Hyparview) []*h.Node, path string) {
+	plot := func(ns func(*h.Hyparview) []h.Node, path string) {
 		act := map[string]int{}
 		for _, v := range w.nodes {
 			for _, n := range ns(&v.Hyparview) {
 				// Count in-degree
-				act[n.ID] += 1
+				act[n.Addr()] += 1
 			}
 		}
 
@@ -160,8 +160,8 @@ func (w *World) plotInDegree() {
 	}
 	af := w.plotPath("in-active")
 	pf := w.plotPath("in-passive")
-	plot(func(v *h.Hyparview) []*h.Node { return v.Active.Nodes }, af)
-	plot(func(v *h.Hyparview) []*h.Node { return v.Passive.Nodes }, pf)
+	plot(func(v *h.Hyparview) []h.Node { return v.Active.Nodes }, af)
+	plot(func(v *h.Hyparview) []h.Node { return v.Passive.Nodes }, pf)
 }
 
 type gossipRound struct {


### PR DESCRIPTION
For future clients, this allows a consumer library to attach arbitrary
meta data to node structs if necessary, while still consuming the core
library.